### PR TITLE
Fix no file rotation when sending sql via psql cli command

### DIFF
--- a/logtofile.c
+++ b/logtofile.c
@@ -247,7 +247,6 @@ static void pgauditlogtofile_emit_log(ErrorData *edata) {
   int exclude_nchars = -2;
 
   if (pgauditlogtofile_is_enabled()) {
-    // printf("ENABLE PRINTF\n");
     if (pg_strncasecmp(edata->message, PGAUDIT_PREFIX_LINE, PGAUDIT_PREFIX_LINE_LENGTH) == 0)
       exclude_nchars = PGAUDIT_PREFIX_LINE_LENGTH;
     else if (pg_strncasecmp(edata->message, INTERCEPT_CONNECTION_PREFIX1, INTERCEPT_CONNECTION_PREFIX1_LENGTH) == 0)
@@ -339,11 +338,6 @@ static bool pgauditlogtofile_needs_rotate_file(void) {
     return true;
   }
 
-  /* Rotate if the global name is different to this backend copy: it has been
-   * rotated */
-  if (strcmp(filename_in_use, pgaudit_log_shm->filename) != 0) {
-    return true;
-  }
 
   /* Rotate if rotation_age is exceeded, and this backend is the first in notice
    * it */
@@ -352,6 +346,13 @@ static bool pgauditlogtofile_needs_rotate_file(void) {
     pgaudit_log_shm->next_rotation_time =
         pgauditlogtofile_calculate_next_rotation_time();
     LWLockRelease(pgaudit_log_shm->lock);
+    return true;
+  }
+
+  /* Rotate if the global name is different to this backend copy: it has been
+   * rotated */
+  if (strcmp(filename_in_use, pgaudit_log_shm->filename) != 0) {
+    printf("Rotate when the global name is different to this backend copy %s %s\n", filename_in_use, pgaudit_log_shm->filename);
     return true;
   }
 

--- a/logtofile.c
+++ b/logtofile.c
@@ -471,12 +471,10 @@ static bool pgauditlogtofile_write_audit(const ErrorData *edata, int exclude_nch
   initStringInfo(&buf);
   /* format the log line */
   pgauditlogtofile_format_audit_line(&buf, edata, exclude_nchars);
-  LWLockAcquire(pgaudit_log_shm->lock, LW_EXCLUSIVE);
   fseek(file_handler, 0L, SEEK_END);
   rc = fwrite(buf.data, 1, buf.len, file_handler);
   pfree(buf.data);
   fflush(file_handler);
-  LWLockRelease(pgaudit_log_shm->lock);
 
   /* If we failed to write the audit to our audit log, use PostgreSQL logger */
   if (rc != buf.len) {


### PR DESCRIPTION
Issue: Audit file is not rotated when sending sql via psql cli command.
How to reproduce:
- Set `pgaudit.log_rotation_age=1` for easier debug.
- Include a SQL command in an inline psql cli command, e.g.
```
psql \
    --host "127.0.0.1" \
    --username "postgres" \
    --dbname "postgres" \
    --command "select
                unnest(e1.extconfig) oid
            from
                pg_catalog.pg_extension e1"
```

My guess: It seems that when the sql command is sent via inline psql cli command, a new process of `pgauditlogtofile` is initialized. That leads to `filename_in_use` is empty and the condition in line 344 `strcmp(filename_in_use, pgaudit_log_shm->filename) != 0` is always true. Additionally, the `pgaudit_log_shm->next_rotation_time` is not updated, because the update only happens in the block of "Rotate if rotation_age is exceeded" => `pgaudit_log_shm->filename` still has the old value.

Solution: Do the block "Rotate if rotation_age is exceeded" before the block "Rotate if the global name is different to the backend copy".