### PR TITLE
Initialize background worker with zero

### DIFF
--- a/logtofile.c
+++ b/logtofile.c
@@ -42,7 +42,7 @@
 */
 void _PG_init(void)
 {
-  BackgroundWorker worker;
+  BackgroundWorker worker = {0};
 
   if (!process_shared_preload_libraries_in_progress)
   {


### PR DESCRIPTION
Particularly, this sets bgw_type to empty which would otherwise print uninitialized data in the "background worker started" log message. (The PG log machinery will fall back to printing bgw_name instead.) We could instead just initialize bgw_type, but it seems safer to initialize all fields.