### PR TITLE
Addition of pgaudit.log_rotation_size option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ Number of minutes after which the audit file will be rotated.
 - If _log_rotation_age < 60_ the rotation background worker will wake up every 10 seconds.
 - If _log_rotation_age > 60_ the rotation background worker will wake up every 1 minute.
 
+### pgaudit.log_rotation_size
+ This parameter determines the maximum size of an individual log file. Turns on only when the parameter is explicitly specified and adds microseconds to the end of the file name, so the 'pgaudit-%Y-%m-%d_%H%M%S.log' pattern is preferred.
+
+**Scope**: System
+
+**Default**: 0
+
 ### pgaudit.log_connections
 Intercepts server log messages emited when log_connections is on
 

--- a/logtofile.c
+++ b/logtofile.c
@@ -72,6 +72,12 @@ void _PG_init(void)
       INT_MAX / SECS_PER_MINUTE, PGC_SIGHUP,
       GUC_NOT_IN_SAMPLE | GUC_UNIT_MIN | GUC_SUPERUSER_ONLY, NULL, NULL, NULL);
 
+  DefineCustomIntVariable(
+    "pgaudit.log_rotation_size",
+    "Automatic rotation of logfiles will happen after that much log output", NULL,
+    &guc_pgaudit_ltf_log_rotation_size, 0, 0, INT_MAX / 1024, PGC_SIGHUP,
+    GUC_NOT_IN_SAMPLE | GUC_SUPERUSER_ONLY | GUC_UNIT_KB, NULL, NULL, NULL);
+
   DefineCustomBoolVariable(
       "pgaudit.log_connections",
       "Intercepts log_connections messages", NULL,

--- a/logtofile_bgw.c
+++ b/logtofile_bgw.c
@@ -56,6 +56,7 @@ void PgAuditLogToFileMain(Datum arg)
   int sleep_ms = SECS_PER_MINUTE * 1000;
   MemoryContext PgAuditLogToFileContext = NULL;
 
+  pgaudit_ltf_shm->worker_latch = &MyProc->procLatch;
   pqsignal(SIGHUP, pgauditlogtofile_sighup);
   pqsignal(SIGINT, SIG_IGN);
   pqsignal(SIGTERM, pgauditlogtofile_sigterm);
@@ -101,6 +102,8 @@ void PgAuditLogToFileMain(Datum arg)
         PgAuditLogToFile_calculate_current_filename();
         PgAuditLogToFile_set_next_rotation_time();
         ereport(DEBUG3, (errmsg("pgauditlogtofile bgw loop new filename %s", pgaudit_ltf_shm->filename)));
+        pgaudit_ltf_shm->size_rotation_flag = false;
+        pgaudit_ltf_shm->total_written_bytes = 0;
       }
     }
 

--- a/logtofile_vars.c
+++ b/logtofile_vars.c
@@ -16,6 +16,7 @@ char *guc_pgaudit_ltf_log_directory = NULL;
 char *guc_pgaudit_ltf_log_filename = NULL;
 char *guc_pgaudit_log_last_rotation = NULL;
 int guc_pgaudit_ltf_log_rotation_age = HOURS_PER_DAY * MINS_PER_HOUR; // Default: 1 day
+int guc_pgaudit_ltf_log_rotation_size = 0;
 bool guc_pgaudit_ltf_log_connections = false;                         // Default: off
 bool guc_pgaudit_ltf_log_disconnections = false;                      // Default: off
 int guc_pgaudit_ltf_auto_close_minutes = 0;                           // Default: off

--- a/logtofile_vars.h
+++ b/logtofile_vars.h
@@ -19,6 +19,7 @@
 #include <port/atomics.h>
 #include <storage/ipc.h>
 #include <storage/lwlock.h>
+#include <storage/latch.h>
 
 #include <pthread.h>
 
@@ -26,6 +27,7 @@
 extern char *guc_pgaudit_ltf_log_directory;
 extern char *guc_pgaudit_ltf_log_filename;
 extern int guc_pgaudit_ltf_log_rotation_age;
+extern int guc_pgaudit_ltf_log_rotation_size;
 extern bool guc_pgaudit_ltf_log_connections;
 extern bool guc_pgaudit_ltf_log_disconnections;
 extern int guc_pgaudit_ltf_auto_close_minutes;
@@ -58,6 +60,9 @@ typedef struct pgAuditLogToFileShm
   size_t num_prefixes_disconnection;
   char filename[MAXPGPATH];
   pg_time_t next_rotation_time;
+  int total_written_bytes;
+  bool size_rotation_flag;
+  Latch *worker_latch;
 } PgAuditLogToFileShm;
 
 // Shared Memory


### PR DESCRIPTION
Adding log file rotation based on the size set in pgaudit.log_rotation_size. The unit of measurement is the same as in PostgreSQL's standard logging. pgaudit.log_rotation_size is only set by the user; otherwise, its functionality will be disabled.