### PR TITLE
Fix: Background worker not starting on replicas

### DIFF
--- a/logtofile.c
+++ b/logtofile.c
@@ -96,7 +96,7 @@ void _PG_init(void)
   /* background worker */
   MemSet(&worker, 0, sizeof(BackgroundWorker));
   worker.bgw_flags = BGWORKER_SHMEM_ACCESS;
-  worker.bgw_start_time = BgWorkerStart_RecoveryFinished;
+  worker.bgw_start_time = BgWorkerStart_ConsistentState;
   worker.bgw_restart_time = 1;
   worker.bgw_main_arg = Int32GetDatum(0);
   worker.bgw_notify_pid = 0;


### PR DESCRIPTION
The background worker that's responsible for log rotation doesn't start on the replica nodes, which results in all audit messages going to a single file until the server is restarted.

According to the PostgreSQL documentation, ConsistentState and RecoveryFinished are equivalent on the leader, and ConsistentState is enough on the hot replicas, meaning it should work for both node roles.

Excerpt from https://www.postgresql.org/docs/current/bgworker.html
> bgw_start_time is the server state during which postgres should start the process; it can be one of BgWorkerStart_PostmasterStart (start as soon as postgres itself has finished its own initialization; processes requesting this are not eligible for database connections), BgWorkerStart_ConsistentState (start as soon as a consistent state has been reached in a hot standby, allowing processes to connect to databases and run read-only queries), and BgWorkerStart_RecoveryFinished (start as soon as the system has entered normal read-write state). Note the last two values are equivalent in a server that's not a hot standby. Note that this setting only indicates when the processes are to be started; they do not stop when a different state is reached.